### PR TITLE
Fix UT-7: Remove commented-out code in InstructionalOffering.hbm.xml

### DIFF
--- a/JavaSource/InstructionalOffering.hbm.xml
+++ b/JavaSource/InstructionalOffering.hbm.xml
@@ -96,20 +96,6 @@
             <one-to-many class="Reservation"/>
         </set>
 
-		<!-- 
-        <set
-            name="creditConfigs"
-            inverse="true"
-            lazy="true"
-            cascade="all-delete-orphan"
-            table="course_credit_unit_config">
-
-            <cache include="non-lazy" usage="transactional"/>
-            <key column="instr_offr_id"/>
-            <one-to-many class="CourseCreditUnitConfig"/>
-        </set>
-         -->
-
         <property
             name="uniqueIdRolledForwardFrom"
             column="uid_rolled_fwd_from"


### PR DESCRIPTION
Closes UT-7

## What was done
Removed the entire commented‑out `<set>` block for `creditConfigs` in `InstructionalOffering.hbm.xml`.

## Why
This dead code was reported by SonarQube as xml:S125 ("Sections of code should not be commented out").  
Deleting it cleans up the file, avoids confusion, and follows best practices.  
The mapping can be restored from Git history if ever needed.

## Jira
UT-7 – Remove commented-out code block in InstructionalOffering.hbm.xml (xml:S125)