### PR TITLE
Fix UT-9: Use \w instead of [A-Za-z0-9_] in regex

### DIFF
--- a/JavaSource/org/unitime/commons/ant/CreateBaseModelFromXml.java
+++ b/JavaSource/org/unitime/commons/ant/CreateBaseModelFromXml.java
@@ -1013,7 +1013,7 @@ public class CreateBaseModelFromXml extends Task {
 					String imp = importMatcher.group(1);
 					existingImports.add(imp);
 				}
-				if (readLine.matches("[\t ]*(public|private|protected)[\t ]*[a-zA-Z<>\\., _\\[\\]\\?]+[\t ]+(get|is)[A-Za-z0-9_]+\\(\\).*")) {
+				if (readLine.matches("[\t ]*(public|private|protected)[\t ]*[a-zA-Z<>\\., _\\[\\]\\?]+[\t ]+(get|is)\\w+\\(\\).*")) {
 					mainImports.add("jakarta.persistence.Transient");
 					needTransient = true;
 				}
@@ -1052,7 +1052,7 @@ public class CreateBaseModelFromXml extends Task {
 					pw.print(mainHeader.toString());
 					classLine = true;
 				}
-				if (line.matches("[\t ]*(public|private|protected)[\t ]*[a-zA-Z<>\\., _\\[\\]\\?]+[\t ]+(get|is)[A-Za-z0-9_]+\\(\\).*") && !"	@Transient".equals(prev)) {
+				if (line.matches("[\t ]*(public|private|protected)[\t ]*[a-zA-Z<>\\., _\\[\\]\\?]+[\t ]+(get|is)\\w+\\(\\).*") && !"	@Transient".equals(prev)) {
 					pw.println("	@Transient");
 				}
 				pw.println(line);


### PR DESCRIPTION
Closes UT-9

## What was done
Replaced verbose character class [A-Za-z0-9_] with the shorthand \w in two regexes inside CreateBaseModelFromXml.java.

## Why
This resolves the SonarQube issue java:S6353 (Regular expression quantifiers and character classes should be used concisely).  
The regex is now shorter and more readable.

## Jira
UT-9 – Replace [A-Za-z0-9_] with \w in regex (java:S6353)