### PR TITLE
Fix UT-10: Parameterize raw Class type in Debug.java

### DIFF
--- a/JavaSource/org/unitime/commons/Debug.java
+++ b/JavaSource/org/unitime/commons/Debug.java
@@ -132,7 +132,7 @@
 		 * @param source a class
 		 * @return class name (without package)
 		 */
-		public static synchronized String getSource(Class source) {
+		public static synchronized String getSource(Class<?> source) {
 			String name = source.getName();
 
 		if (name != null && name.indexOf('.') >= 0) {


### PR DESCRIPTION
Closes UT-10

## What was done
Changed `Class source` to `Class<?> source` in `Debug.getSource()`.

## Why
This resolves the SonarQube issue java:S3740 (Raw types should not be used).
Adding a wildcard parameter eliminates the raw type and improves type safety.

## Jira
UT-10 – Raw types should not be used in Debug.java